### PR TITLE
Add dedup helper, PyInstaller spec, and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,25 @@
-name: build-exe
+name: build
+
 on:
   push:
+    branches: [main]
     tags: ['v*']
+
 jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with: {python-version: '3.11'}
-    - run: pip install -r requirements.txt
-    - run: pyinstaller gui.py --onefile --noconsole
-    - uses: softprops/action-gh-release@v1
-      with: {files: dist/gui.exe}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pyinstaller bank2zen.spec
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bank2zen
+          path: dist/bank2zen.exe
+      - if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/bank2zen.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 venv/
 __pycache__/
-dist/
-build/
 *.spec
+build/
+dist/
+.idea/
+
 *.xlsx
 *.csv
 new_desc.xlsx

--- a/bank2zen.spec
+++ b/bank2zen.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+block_cipher = None
+
+a = Analysis(
+    ['gui_tk.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('categories.json', '.'),
+        ('accounts_to.json', '.'),
+        ('bank2zen.py', '.')
+    ],
+    hiddenimports=['openpyxl'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='bank2zen',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='bank2zen'
+)

--- a/dedup_json.py
+++ b/dedup_json.py
@@ -1,22 +1,38 @@
-import json, pathlib, sys
+import json
+from pathlib import Path
 
-def dedup(path: str):
-    p = pathlib.Path(path)
+FILES = ("categories.json", "accounts_to.json")
+
+
+def _dedup_file(path: str) -> int:
+    p = Path(path)
     if not p.exists():
-        print(f"{path}: not found"); return
-    data = json.load(open(p, encoding='utf-8'))
-    changed = False
+        print(f"{path}: not found")
+        return 0
+    data = json.load(open(p, encoding="utf-8"))
+    removed = 0
     for k, lst in data.items():
-        unique = sorted(set(lst), key=lst.index)   # сохраняем порядок
-        if len(unique) != len(lst):
-            data[k] = unique
-            changed = True
-    if changed:
-        json.dump(data, open(p, 'w', encoding='utf-8'),
-                  ensure_ascii=False, indent=2)
-        print(f"{path}: duplicates removed")
+        uniq = []
+        for item in lst:
+            if item not in uniq:
+                uniq.append(item)
+        removed += len(lst) - len(uniq)
+        data[k] = uniq
+    if removed:
+        json.dump(data, open(p, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+        print(f"{path}: {removed} duplicates removed")
     else:
         print(f"{path}: already clean")
+    return removed
 
-for f in ("categories.json", "accounts_to.json"):
-    dedup(f)
+
+def dedup_json() -> int:
+    total = 0
+    for f in FILES:
+        total += _dedup_file(f)
+    print(f"Total cleaned: {total}")
+    return total
+
+
+if __name__ == "__main__":
+    dedup_json()

--- a/gui_tk.py
+++ b/gui_tk.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import pandas as pd, json, pathlib
 from bank2zen import convert, normalize, CATS_FILE, ACC_FILE
+from dedup_json import dedup_json
 
 # ── справочники ───────────────────────────────────────────────────────────────
 CATS = sorted([
@@ -131,6 +132,7 @@ class AssignWin(tk.Toplevel):
 class App(tk.Tk):
     def __init__(self):
         super().__init__()
+        dedup_json()
         self.title('bank2zen — Fineco → ZenMoney'); self.geometry('770x360')
         frm=ttk.Frame(self,padding=10); frm.grid(sticky='nsew')
         self.columnconfigure(0,weight=1); frm.columnconfigure(1,weight=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 openpyxl
-PySimpleGUI
+tk ; sys_platform == "win32"
 pyinstaller

--- a/setup_and_build.ps1
+++ b/setup_and_build.ps1
@@ -1,0 +1,3 @@
+python -m venv venv
+venv\Scripts\pip install -r requirements.txt
+venv\Scripts\pyinstaller bank2zen.spec


### PR DESCRIPTION
## Summary
- keep repo tidy and streamline requirements
- ensure categories and accounts JSONs stay deduped
- call dedup_json at GUI start
- provide PyInstaller spec and GitHub Actions workflow
- add optional Windows helper script

## Testing
- `python -m py_compile bank2zen.py gui_tk.py dedup_json.py`
- `python dedup_json.py`

------
https://chatgpt.com/codex/tasks/task_e_68630e8a511c8333a87e245c331552e1