### PR TITLE
CI: bump actions to v4/v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - run: pyinstaller bank2zen.spec
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bank2zen
           path: dist/bank2zen.exe


### PR DESCRIPTION
## Summary
- update workflow actions to use `upload-artifact@v4`
- keep using `checkout@v4` and `setup-python@v5`

## Testing
- `python -m py_compile bank2zen.py dedup_json.py gui_tk.py`

------
https://chatgpt.com/codex/tasks/task_e_686311a37e9c833384faf96658ade217