### PR TITLE
Fix AssignWin Amount column

### DIFF
--- a/gui_tk.py
+++ b/gui_tk.py
@@ -146,8 +146,10 @@ class AssignWin(tk.Toplevel):
         )
         self.lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True); sb.config(command=self.lb.yview)
         for _, r in self.df.iterrows():
-            amt = r["Income"] if pd.notna(r["Income"]) else -r["Expense"]
-            self.lb.insert(tk.END, f"{r['Data']} | {amt:+.2f} | {r['Descrizione_Completa']}")
+            self.lb.insert(
+                tk.END,
+                f"{r['Data']} | {r['Amount']:+.2f} | {r['Descrizione_Completa']}"
+            )
         # controls
         bar = tk.Frame(self); bar.pack(pady=6)
         self.cmb = AutoCombo(bar, values=CATS, width=70); self.cmb.grid(row=0, column=0, padx=5)


### PR DESCRIPTION
## Summary
- show Amount instead of Income/Expense when assigning categories

## Testing
- `git commit -m "fix: AssignWin uses Amount column (no Income/Expense in new_desc.xlsx)"`
- `git push` *(fails: no configured destination)*

------
https://chatgpt.com/codex/tasks/task_e_6869522c55e883338a78987d67b69543