### PR TITLE
Improve Excel import robustness

### DIFF
--- a/bank2zen.py
+++ b/bank2zen.py
@@ -26,6 +26,90 @@ def normalize(t: str) -> str:
     t = re.sub(r"\s{2,}", " ", t)
     return t.strip().lower()
 
+def _norm_cell(value) -> str:
+    value = "" if value is None else str(value)
+    return re.sub(r"[^a-z0-9]", "", value.strip().lower())
+
+_ALIASES = {
+    "Data_Valuta": {
+        "datavaluta", "dataval", "datavalut", "data"
+    },
+    "Entrate": {
+        "entrate", "ebt", "income", "crediti", "accredito"
+    },
+    "Uscite": {
+        "uscite", "usc", "expense", "addebiti", "debito", "spese"
+    },
+    "Descrizione": {
+        "descrizione", "descr", "discr", "description", "causale"
+    },
+    "Descrizione_Completa": {
+        "descrizionecompleta", "descrcompleta", "discrcompleta",
+        "descrizionecomplet", "fulldescription", "dettaglio"
+    },
+}
+
+def _read_movements_xlsx(path: str) -> pd.DataFrame:
+    raw = pd.read_excel(path, header=None, engine="openpyxl")
+    hdr_idx = None
+    target_keys = _ALIASES["Data_Valuta"]
+
+    for idx in range(len(raw)):
+        row_vals = {
+            _norm_cell(v)
+            for v in raw.iloc[idx].tolist()
+            if pd.notna(v) and str(v).strip()
+        }
+        if row_vals & target_keys:
+            hdr_idx = idx
+            break
+
+    if hdr_idx is None:
+        raise ValueError("Не удалось найти заголовок 'Data_Valuta' в XLSX. Проверьте шаблон выгрузки.")
+
+    if hdr_idx:
+        print(f"Пропущено строк до шапки: {hdr_idx}")
+
+    df = pd.read_excel(path, header=hdr_idx, engine="openpyxl")
+
+    rename_map = {}
+    for col in df.columns:
+        key = _norm_cell(col)
+        for canon, keys in _ALIASES.items():
+            if key in keys:
+                rename_map[col] = canon
+                break
+
+    df = df.rename(columns=rename_map)
+
+    if "Data_Valuta" not in df.columns:
+        raise ValueError("Колонка даты Data_Valuta не найдена.")
+
+    if not ({"Entrate", "Uscite"} & set(df.columns)):
+        raise ValueError("В XLSX нет колонок сумм (Entrate/Uscite).")
+
+    if not ({"Descrizione", "Descrizione_Completa"} & set(df.columns)):
+        raise ValueError("В XLSX нет колонок описания (Descrizione/Descrizione_Completa).")
+
+    if "Descrizione_Completa" not in df.columns and "Descrizione" in df.columns:
+        df["Descrizione_Completa"] = df["Descrizione"]
+
+    keep = ["Data_Valuta", "Entrate", "Uscite", "Descrizione", "Descrizione_Completa"]
+    present = [c for c in keep if c in df.columns]
+    df = df[present].copy()
+
+    df["Data_Valuta"] = pd.to_datetime(df["Data_Valuta"], dayfirst=True, errors="coerce")
+    missing_dates = df["Data_Valuta"].isna().sum()
+    if missing_dates:
+        print(f"Предупреждение: отброшено строк без даты: {missing_dates}")
+        df = df[df["Data_Valuta"].notna()].copy()
+
+    for col in ("Entrate", "Uscite"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0).abs()
+
+    return df
+
 def _load(p):
     if Path(p).exists():
         try:
@@ -42,15 +126,16 @@ def _lookup(nrm, table):
 
 # ── конвертер ────────────────────────────────────────────────────────────────
 def convert(xlsx):
-    # ищем строку, где начинается шапка
-    hdr = next(i for i, v in enumerate(
-        pd.read_excel(xlsx, header=None).iloc[:, 0]) if str(v).strip() == "Data")
+    df = _read_movements_xlsx(xlsx)
 
-    df = (
-        pd.read_excel(xlsx, header=hdr,
-                      dtype={"Entrate": float, "Uscite": float})
-        .dropna(subset=["Data"])
-    )
+    df = df.copy()
+    df["Data"] = df["Data_Valuta"]
+    if "Descrizione" not in df.columns:
+        df["Descrizione"] = df["Descrizione_Completa"]
+    if "Entrate" not in df.columns:
+        df["Entrate"] = 0.0
+    if "Uscite" not in df.columns:
+        df["Uscite"] = 0.0
 
     df["Norm"] = df["Descrizione_Completa"].apply(lambda s: normalize(str(s)))
 
@@ -62,7 +147,7 @@ def convert(xlsx):
 
     # ── пост-обработка строк ─────────────────────────────
     def split(row):
-        desc_short = str(row["Descrizione"])          # ← короткое описание
+        desc_short = str(row.get("Descrizione", ""))  # ← короткое описание
         full       = str(row["Descrizione_Completa"]).lower()
         inc  = row["Entrate"] if pd.notna(row["Entrate"]) else ""
         out  = abs(row["Uscite"]) if pd.notna(row["Uscite"]) else ""


### PR DESCRIPTION
## Summary
- add a pandas helper that autodetects the Fineco header row and normalizes canonical column names
- keep only the required columns and coerce dates and amounts into the expected formats while logging skipped rows
- integrate the new loader into convert() so the downstream pipeline keeps working with positive income/expense amounts

## Testing
- python -m compileall bank2zen.py

------
https://chatgpt.com/codex/tasks/task_e_68d1b34d26f083338bc81a273145e814