### PR TITLE
Add persistent history index and GUI tools

### DIFF
--- a/bank2zen.py
+++ b/bank2zen.py
@@ -2,6 +2,7 @@
 
 import pandas as pd, json, re, sys, os
 from pathlib import Path
+from history_index import ensure_db, fingerprint, seen_lookup, mark_seen
 
 # ── ваши счета ────────────────────────────────────────────────────────────────
 ACC_DEBIT   = "Fineco Debit"
@@ -137,10 +138,62 @@ def convert(xlsx):
     if "Uscite" not in df.columns:
         df["Uscite"] = 0.0
 
+    df["Data_Valuta"] = pd.to_datetime(df["Data_Valuta"], dayfirst=True, errors="coerce")
+    df = df[df["Data_Valuta"].notna()].copy()
+
+    entr = pd.to_numeric(df.get("Entrate", 0), errors="coerce").fillna(0).abs()
+    usct = pd.to_numeric(df.get("Uscite", 0), errors="coerce").fillna(0).abs()
+
+    direction = pd.Series("I", index=df.index)
+    direction.loc[usct > 0] = "O"
+    amount = entr.copy()
+    amount.loc[usct > 0] = usct[usct > 0]
+    amount = amount.round(2)
+    amount_cents = (amount * 100).round(0).astype("int64")
+
+    if "Descrizione_Completa" in df.columns:
+        desc_full_source = df["Descrizione_Completa"]
+    else:
+        desc_full_source = df.get("Descrizione", "")
+    account_source = df.get("Account", "")
+
+    keys = []
+    for i in df.index:
+        date_iso = df.at[i, "Data_Valuta"].date().isoformat()
+        dirc = direction.at[i]
+        cents = int(amount_cents.at[i])
+        if isinstance(desc_full_source, pd.Series):
+            text = str(desc_full_source.at[i]) if pd.notna(desc_full_source.at[i]) else ""
+        else:
+            text = str(desc_full_source) if desc_full_source is not None else ""
+        if isinstance(account_source, pd.Series):
+            acc_val = str(account_source.at[i]) if i in account_source.index else ""
+        else:
+            acc_val = str(account_source) if account_source is not None else ""
+        keys.append(fingerprint(date_iso, dirc, cents, text, acc_val))
+
+    con = ensure_db()
+    already = seen_lookup(con, keys)
+    df["__key__"] = keys
+    new_mask = ~df["__key__"].isin(already)
+    dupes = int((~new_mask).sum())
+    news = int(new_mask.sum())
+    print(f"[bank2zen] Dedup: skipped {dupes}, new {news}")
+
+    df = df.loc[new_mask].copy()
+    if df.empty:
+        con.close()
+        return "no_new"
+
+    entr = entr.loc[df.index]
+    usct = usct.loc[df.index]
+    direction = direction.loc[df.index]
+    amount = amount.loc[df.index]
+
     df["Norm"] = df["Descrizione_Completa"].apply(lambda s: normalize(str(s)))
 
-    inc = pd.to_numeric(df.get("Entrate", 0), errors="coerce").fillna(0).abs()
-    out = pd.to_numeric(df.get("Uscite", 0), errors="coerce").fillna(0).abs()
+    inc = entr
+    out = usct
 
     df["Income"] = ""
     df["Expense"] = ""
@@ -208,14 +261,41 @@ def convert(xlsx):
         unknown[["Data", "Entrate", "Uscite", "Descrizione_Completa"]].to_excel(
             "new_desc.xlsx", index=False
         )
+        con.close()
         return "need_class"
 
     # ── итоговый CSV ────────────────────────────────────
     cols = ["Data","Category","Descrizione_Completa",
             "Account","AccountTo","Income","Expense"]
-    df_final = df.copy()
+    df_final = df.drop(columns=["__key__"]).copy()
     df_final.to_csv("out_zenmoney.csv", columns=cols,
                     index=False, encoding="utf-8-sig", sep=";")
+
+    if "Descrizione_Completa" in df.columns:
+        desc_full_current = df["Descrizione_Completa"]
+    else:
+        desc_full_current = df.get("Descrizione", "")
+    account_current = df.get("Account", "")
+
+    rows_to_index = []
+    src_name = Path(xlsx).name
+    for i in df.index:
+        d = df.at[i, "Data_Valuta"].date().isoformat()
+        dirc = "O" if (usct.at[i] > 0) else "I"
+        amt = float(amount.at[i])
+        if isinstance(desc_full_current, pd.Series):
+            text = str(desc_full_current.at[i]) if pd.notna(desc_full_current.at[i]) else ""
+        else:
+            text = str(desc_full_current) if desc_full_current is not None else ""
+        if isinstance(account_current, pd.Series):
+            acc_val = str(account_current.at[i]) if i in account_current.index else ""
+        else:
+            acc_val = str(account_current) if account_current is not None else ""
+        key = df.at[i, "__key__"]
+        rows_to_index.append((key, d, dirc, amt, acc_val, "", "", src_name))
+    if rows_to_index:
+        mark_seen(con, rows_to_index)
+    con.close()
     return "ok"
 
 # ── CLI ───────────────────────────────────────────────────────────────────────

--- a/gui_tk.py
+++ b/gui_tk.py
@@ -1,7 +1,12 @@
+import os
+import sys
+import subprocess
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import pandas as pd, json, pathlib
-from bank2zen import convert, normalize, CATS_FILE, ACC_FILE
+from pathlib import Path
+from bank2zen import convert, normalize, CATS_FILE, ACC_FILE, _read_movements_xlsx
+from history_index import db_path, ensure_db, seen_lookup, mark_seen
 from dedup_json import dedup_file
 
 for f in ("categories.json", "accounts_to.json"):
@@ -309,6 +314,7 @@ class App(tk.Tk):
         ttk.Button(frm,text='Exit',command=self.destroy).grid(row=1,column=2,sticky='ew',padx=5)
         self.log_box=tk.Text(frm,height=10,state='disabled')
         self.log_box.grid(row=2,column=0,columnspan=3,sticky='nsew'); frm.rowconfigure(2,weight=1)
+        self._make_menubar()
 
     def log(self,msg):
         self.log_box['state']='normal'; self.log_box.insert(tk.END,msg+'\n')
@@ -325,6 +331,9 @@ class App(tk.Tk):
             res=convert(fn)
         except PermissionError:
             messagebox.showerror('Ошибка','Файл выгрузки открыт.')
+            return
+        if res=='no_new':
+            self.log('Новых операций нет.')
             return
         if res=='ok':
             self.log('CSV создан → Review')
@@ -343,6 +352,9 @@ class App(tk.Tk):
         except PermissionError:
             messagebox.showerror('Ошибка','Файл выгрузки открыт.')
             return
+        if res2=='no_new':
+            self.log('Новых операций нет.')
+            return
         if res2=='ok':
             self.log('CSV создан → Review')
             Review(self,pd.read_csv('out_zenmoney.csv',sep=';'))
@@ -352,6 +364,156 @@ class App(tk.Tk):
                 self.log(f'Осталось разметить {left} строк.')
             else:
                 self.log('new_desc.xlsx не найден')
+
+    def _make_menubar(self):
+        try:
+            m = tk.Menu(self)
+            tools = tk.Menu(m, tearoff=0)
+            tools.add_command(label="Open history folder", command=self._open_history_dir)
+            tools.add_separator()
+            tools.add_command(label="Seed history from folder…", command=self._seed_history_from_folder)
+            tools.add_separator()
+            tools.add_command(label="Reset history…", command=self._reset_history)
+            m.add_cascade(label="Tools", menu=tools)
+            self.config(menu=m)
+        except Exception as e:
+            self.log(f"Menu init error: {e}")
+
+    def _history_dir(self) -> Path:
+        try:
+            return Path(db_path()).parent
+        except Exception:
+            return Path.home() / ".bank2zen"
+
+    def _open_history_dir(self):
+        p = self._history_dir()
+        p.mkdir(parents=True, exist_ok=True)
+        try:
+            if sys.platform.startswith('win'):
+                os.startfile(str(p))  # type: ignore[attr-defined]
+            elif sys.platform == 'darwin':
+                subprocess.Popen(['open', str(p)])
+            else:
+                subprocess.Popen(['xdg-open', str(p)])
+            self.log(f"Opened history folder: {p}")
+        except Exception as e:
+            self.log(f"Cannot open folder: {p} ({e})")
+            messagebox.showinfo('bank2zen', f"History folder:\n{p}")
+
+    def _reset_history(self):
+        if not messagebox.askyesno('bank2zen', 'Reset history index?\nThis will forget all previously imported transactions.'):
+            return
+        p = Path(db_path())
+        try:
+            if p.exists():
+                try:
+                    p.unlink()
+                    self.log('History reset: file deleted.')
+                    messagebox.showinfo('bank2zen', 'History reset.\nFile removed.')
+                    return
+                except Exception:
+                    pass
+            con = ensure_db()
+            try:
+                con.execute('DELETE FROM seen')
+                con.execute('VACUUM')
+                con.commit()
+            finally:
+                con.close()
+            self.log('History reset: table cleared.')
+            messagebox.showinfo('bank2zen', 'History reset.\nTable cleared.')
+        except Exception as e:
+            self.log(f'History reset error: {e}')
+            messagebox.showerror('bank2zen', f'Error resetting history:\n{e}')
+
+    def _seed_history_from_folder(self):
+        folder = filedialog.askdirectory(title='Select folder with XLSX exports')
+        if not folder:
+            return
+        only90 = messagebox.askyesno('bank2zen', 'Seed only last 90 days?\nYes = last 90 days, No = all history.')
+        from datetime import date, timedelta
+        since = date.today() - timedelta(days=90) if only90 else None
+
+        con = ensure_db()
+        folder = Path(folder)
+        files = sorted(folder.glob('*.xlsx'))
+        total = dupes = new = 0
+
+        for xf in files:
+            try:
+                df = _read_movements_xlsx(str(xf))
+                if df.empty:
+                    continue
+                df['Data_Valuta'] = pd.to_datetime(df['Data_Valuta'], dayfirst=True, errors='coerce')
+                df = df[df['Data_Valuta'].notna()].copy()
+                if since is not None:
+                    df = df[df['Data_Valuta'].dt.date >= since]
+                if df.empty:
+                    continue
+
+                entr = pd.to_numeric(df.get('Entrate', 0), errors='coerce').fillna(0).abs()
+                usct = pd.to_numeric(df.get('Uscite', 0), errors='coerce').fillna(0).abs()
+
+                direction = pd.Series('I', index=df.index)
+                direction.loc[usct > 0] = 'O'
+                amount = entr.copy()
+                amount.loc[usct > 0] = usct[usct > 0]
+                amount = amount.round(2)
+
+                if 'Descrizione_Completa' in df.columns:
+                    desc_full = df['Descrizione_Completa']
+                else:
+                    desc_full = df.get('Descrizione', '')
+                account = df.get('Account', '')
+
+                keys = []
+                from history_index import fingerprint  # local import avoids circulars
+                for i in df.index:
+                    date_iso = df.at[i, 'Data_Valuta'].date().isoformat()
+                    dirc = direction.at[i]
+                    cents = int((amount.at[i] * 100))
+                    if isinstance(desc_full, pd.Series):
+                        text = str(desc_full.at[i]) if pd.notna(desc_full.at[i]) else ''
+                    else:
+                        text = str(desc_full) if desc_full is not None else ''
+                    if isinstance(account, pd.Series):
+                        acc_val = str(account.at[i]) if i in account.index else ''
+                    else:
+                        acc_val = str(account) if account is not None else ''
+                    keys.append(fingerprint(date_iso, dirc, cents, text, acc_val))
+
+                found = seen_lookup(con, keys)
+                seen_local = set(found)
+                to_ins = []
+                for j, key in enumerate(keys):
+                    total += 1
+                    if key in seen_local:
+                        dupes += 1
+                        continue
+                    i = df.index[j]
+                    d = df.at[i, 'Data_Valuta'].date().isoformat()
+                    dirc = direction.at[i]
+                    amt = float(amount.at[i])
+                    if isinstance(desc_full, pd.Series):
+                        text = str(desc_full.at[i]) if pd.notna(desc_full.at[i]) else ''
+                    else:
+                        text = str(desc_full) if desc_full is not None else ''
+                    if isinstance(account, pd.Series):
+                        acc_val = str(account.at[i]) if i in account.index else ''
+                    else:
+                        acc_val = str(account) if account is not None else ''
+                    to_ins.append((key, d, dirc, amt, acc_val, '', '', xf.name))
+                    seen_local.add(key)
+                if to_ins:
+                    mark_seen(con, to_ins)
+                    new += len(to_ins)
+                self.log(f'Seeded from {xf.name}: +{len(to_ins)} new, {len(found)} seen total.')
+            except Exception as e:
+                self.log(f'Seed error {xf.name}: {e}')
+
+        messagebox.showinfo('bank2zen', f'Seed done.\nFiles: {len(files)}\nNew: {new}\nDuplicates: {dupes}\nScanned rows: {total}')
+        self.log(f'Seed done. Files={len(files)} New={new} Duplicates={dupes} TotalRows={total}')
+        con.close()
 
 if __name__ == '__main__':
     import pandas as pd

--- a/history_index.py
+++ b/history_index.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+import os
+import re
+import sqlite3
+import time
+import hashlib
+from pathlib import Path
+
+
+def _state_dir() -> Path:
+    if os.name == "nt":
+        base = os.getenv("APPDATA") or str(Path.home())
+        p = Path(base) / "bank2zen"
+    else:
+        p = Path.home() / ".bank2zen"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def db_path() -> Path:
+    return _state_dir() / "seen.sqlite"
+
+
+def ensure_db() -> sqlite3.Connection:
+    con = sqlite3.connect(db_path())
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS seen(
+            key TEXT PRIMARY KEY,
+            date TEXT,
+            direction TEXT,
+            amount REAL,
+            account TEXT,
+            token1 TEXT,
+            token2 TEXT,
+            source TEXT,
+            created_at REAL
+        )
+    """
+    )
+    return con
+
+
+def _norm_text(s: str) -> str:
+    s = (s or "").strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+def _tokens(s: str):
+    # optional stable IDs from text: last4, CRO/TRN, generic ID
+    last4 = None
+    m = re.search(r"carta\s*n\.?\s*\*+\s*(\d{3,4})", s, re.I)
+    if m:
+        last4 = m.group(1)
+
+    crotrn = None
+    m = re.search(r"\b(CRO|TRN)\s*[: ]?\s*([A-Z0-9]{6,})", s, re.I)
+    if m:
+        crotrn = f"{m.group(1).upper()}:{m.group(2).upper()}"
+
+    ppid = None
+    m = re.search(r"\bID\s*[:#]?\s*([A-Z0-9]{10,})", s, re.I)
+    if m:
+        ppid = m.group(1).upper()
+    return (last4 or ""), (crotrn or ""), (ppid or "")
+
+
+def fingerprint(
+    date_iso: str,
+    direction: str,
+    amount_cents: int,
+    descr_full: str,
+    account: str = "",
+    extra: str = "",
+) -> str:
+    dnorm = _norm_text(descr_full)
+    t1, t2, t3 = _tokens(dnorm)
+    key_str = "|".join(
+        [
+            date_iso,
+            direction,
+            str(amount_cents),
+            (account or ""),
+            t1,
+            t2,
+            t3,
+            dnorm,
+        ]
+    )
+    return hashlib.sha1(key_str.encode("utf-8")).hexdigest()
+
+
+def seen_lookup(con: sqlite3.Connection, keys: list[str]) -> set[str]:
+    if not keys:
+        return set()
+    found = set()
+    for i in range(0, len(keys), 500):
+        chunk = keys[i : i + 500]
+        q = "SELECT key FROM seen WHERE key IN (%s)" % ",".join("?" * len(chunk))
+        for (k,) in con.execute(q, chunk):
+            found.add(k)
+    return found
+
+
+def mark_seen(con: sqlite3.Connection, rows):
+    """
+    rows: iterable of tuples (key, date_iso, direction, amount, account, token1, token2, source)
+    """
+    now = time.time()
+    con.executemany(
+        "INSERT OR IGNORE INTO seen(key,date,direction,amount,account,token1,token2,source,created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+        [(k, d, dr, amt, acc, t1, t2, src, now) for (k, d, dr, amt, acc, t1, t2, src) in rows],
+    )
+    con.commit()


### PR DESCRIPTION
## Summary
- add a SQLite-backed `history_index` module for persistent seen lookups and inserts
- integrate deduplication and seen marking into `convert()` so repeated movements are skipped
- extend the Tk GUI with a Tools menu to manage the history database and handle the "no new" result

## Testing
- python -m compileall bank2zen.py gui_tk.py history_index.py

------
https://chatgpt.com/codex/tasks/task_e_68d70e3297308333b1c8e0534c2b3471